### PR TITLE
JSON field support

### DIFF
--- a/flask_peewee/db.py
+++ b/flask_peewee/db.py
@@ -1,3 +1,4 @@
+import json
 import peewee
 from peewee import *
 
@@ -51,3 +52,20 @@ class Database(object):
     def register_handlers(self):
         self.app.before_request(self.connect_db)
         self.app.after_request(self.close_db)
+
+
+class JSONColumn(peewee.TextColumn):
+    def db_value(self, value):
+        if value:
+            value = json.dumps(value)
+        return value
+
+    def python_value(self, value):
+        if value:
+            value = json.loads(value)
+        return value
+
+
+class JSONField(peewee.Field):
+    column_class = JSONColumn
+

--- a/flask_peewee/filters.py
+++ b/flask_peewee/filters.py
@@ -2,6 +2,7 @@ import datetime
 import operator
 
 from flask import request
+from flask_peewee.db import JSONField
 from flask_peewee.utils import models_to_path
 from peewee import *
 
@@ -30,7 +31,7 @@ LOOKUP_TYPES = {
 
 FIELD_TYPES = {
     'foreign_key': [ForeignKeyField],
-    'text': [CharField, TextField],
+    'text': [CharField, TextField, JSONField],
     'numeric': [PrimaryKeyField, IntegerField, FloatField, DecimalField, DoubleField],
     'boolean': [BooleanField],
     'datetime': [DateTimeField, DateField],


### PR DESCRIPTION
This adds basic JSONField support to flask-peewee. A common model these days with web applications is to support some level of "document" in the database for dynamic attributes. Generally these are stored as varchar fields in the schema. This commit:
- Adds JSON support/validation to the admin panels.
- Adds a JSONField that uses json.load/json.dump to store Python objects as json strings.

Maybe there are things I am missing, or other places I should also have added JSONField support. Not positive.
