### PR TITLE
update flask-peewee documentation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ requirements:
 * python 2.5 or greater
 
 
-check out the `documentation <http://charlesleifer.com/docs/flask-peewee/>`_.
+check out the `documentation <http://flask-peewee.readthedocs.org/>`_.
 
 
 admin interface


### PR DESCRIPTION
this one was also pointing to the old location.
