### PR TITLE
get_pages now returns an integer

### DIFF
--- a/flask_peewee/utils.py
+++ b/flask_peewee/utils.py
@@ -40,7 +40,7 @@ class PaginatedQuery(object):
         return 1
 
     def get_pages(self):
-        return math.ceil(float(self.query.count()) / self.paginate_by)
+        return int(math.ceil(float(self.query.count()) / self.paginate_by))
 
     def get_list(self):
         return self.query.paginate(self.get_page(), self.paginate_by)


### PR DESCRIPTION
get_pages now returns an integer, so you can iterate over the page numbers. Something like:

```
{% for x in range(pagination.get_pages()) %}
         {% if x == page %}
            <span style="text-weight: bold;">{{ x }}</span>
        {% else %}    
            <a href="?page={{ x }}">{{ x }}</a>
        {% endif %}    
{% endfor %}
```

Math.ceil() returns an integer value (that's the point of ceiling) as a float. Apparently this is changed in Python 3.0, but for the time being this would be a nice solution.
