### PR TITLE
Allowing users to authenticate with email

### DIFF
--- a/flask_peewee/auth.py
+++ b/flask_peewee/auth.py
@@ -38,6 +38,8 @@ class Auth(object):
 
         self.clear_session = clear_session
         self.default_next_url = default_next_url
+        
+        self.id_type = id_type
 
         self.setup()
 


### PR DESCRIPTION
Default usage is preserved, but if id_type parameter is passed to authenticate() it can be decided whether username or email is used for authentication.
