### PR TITLE
Correct handling of IN operator argument

### DIFF
--- a/flask_peewee/rest.py
+++ b/flask_peewee/rest.py
@@ -230,9 +230,9 @@ class RestResource(object):
         constructor = lambda kwargs: negated and ~DQ(**kwargs) or DQ(**kwargs)
         if op == 'in':
             # in gives us a string format list '1,2,3,4'
-            # we have to turn it into a list of integers before passing to
+            # we have to turn it into a list before passing to
             # the filter.
-            arg_list = [int(i) for i in arg_list[0].split(',')]
+            arg_list = [i.strip() for i in arg_list[0].split(',')]
             return query.filter(constructor({query_expr: arg_list}))
         elif len(arg_list) == 1:
             return query.filter(constructor({query_expr: arg_list[0]}))

--- a/flask_peewee/tests/rest.py
+++ b/flask_peewee/tests/rest.py
@@ -622,6 +622,12 @@ class RestApiBasicTestCase(RestApiTestCase):
         resp_json = self.response_json(resp)
         self.assertAPINotes(resp_json, Note.filter(id__in=[1,2,5]).order_by(Note.id))
 
+        # also test that the IN operator works with list of strings
+        resp = self.app.get('/api/user/?username__in=admin,normal')
+        resp_json = self.response_json(resp)
+        self.assertAPIUsers(resp_json, User.filter(username__in=['admin', 'normal']).order_by(User.id))
+
+
     def test_filter_with_pagination(self):
         users, notes = self.get_users_and_notes()
         notes = list(self.admin.note_set.order_by(Note.id))


### PR DESCRIPTION
Filter with IN operator was not working, due to i,j,k being treated as a
single string. Added casting to address this, and extended a test to
check it.
