### PR TITLE
Auth - parameter to override db table name

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -437,7 +437,7 @@ Extending admin functionality using AdminPanel
 Auth
 ----
 
-.. py:class:: Auth(app, db[, user_model=None[, prefix='/accounts']])
+.. py:class:: Auth(app, db[, user_model=None[, prefix='/accounts']], db_table='user')
 
     The class that provides methods for authenticating users and tracking
     users across requests.  It also provides a model for persisting users to
@@ -485,6 +485,7 @@ Auth
     :param db: :py:class:`Database` database wrapper for flask app
     :param user_model: ``User`` model to use
     :param prefix: url to bind authentication views to, defaults to /accounts/
+    :param db_table: Create db table using db_table name. ``user`` is reserved keyword in postgres.
 
     .. py:attribute:: default_next_url = 'homepage'
 

--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -40,6 +40,8 @@ an :py:class:`Auth` backend for your project:
     # needed for authentication
     auth = Auth(app, db)
 
+.. note::
+    ``user`` is reserverd keyword in Postgres. Pass db_table to Auth to override db table.
 
 Marking areas of the site as login required
 -------------------------------------------

--- a/flask_peewee/auth.py
+++ b/flask_peewee/auth.py
@@ -40,10 +40,11 @@ class BaseUser(object):
 
 class Auth(object):
     def __init__(self, app, db, user_model=None, prefix='/accounts', name='auth',
-                 clear_session=False, default_next_url='/'):
+                 clear_session=False, default_next_url='/', db_table='user'):
         self.app = app
         self.db = db
 
+        self.db_table = db_table
         self.User = user_model or self.get_user_model()
 
         self.blueprint = self.get_blueprint(name)
@@ -67,6 +68,9 @@ class Auth(object):
 
             def __unicode__(self):
                 return self.username
+
+            class Meta:
+                db_table = self.db_table  # Postgres reserves user as a keyword
 
         return User
 


### PR DESCRIPTION
user is reserved keyword in postgres. Every postgres who want to use Auth will have to add meta class in custom model as per https://github.com/coleifer/flask-peewee/issues/14

``` python
class Meta:
        db_table = 'users' # Postgres reserves user as a keyword
```

IMO, this should be made part of Auth with ability to user to customize db tablename.

``` python
class Meta:
    db_table = self.db_table  # Postgres reserves user as a keyword
```

where db_table can be passed to Auth i.e. 

``` python
auth = Auth(app, db, db_table='auth_user')
```
