### PR TITLE
support for deferred initialization

### DIFF
--- a/flask_peewee/db.py
+++ b/flask_peewee/db.py
@@ -7,6 +7,7 @@ from flask_peewee.utils import load_class
 
 class Database(object):
     def __init__(self, app=None):
+    	self.database = None
         if app is not None:
             self.init_app(app)
 
@@ -16,7 +17,7 @@ class Database(object):
         self.load_database()
         self.register_handlers()
 
-        self.Model = self.get_model_class()    	
+        self.Model = self.get_model_class()
 
     def load_database(self):
         self.database_config = dict(self.app.config['DATABASE'])


### PR DESCRIPTION
The `init_app()` method has been added so that the `Database` object can be instantiated without requiring an `app` object.
