### PR TITLE
Fixed 'next' argument not being added to the login URL in the login form

### DIFF
--- a/flask_peewee/auth.py
+++ b/flask_peewee/auth.py
@@ -202,7 +202,7 @@ class Auth(object):
             'auth/login.html',
             error=error,
             form=form,
-            login_url=url_for('%s.login' % self.blueprint.name))
+            login_url=url_for('%s.login' % self.blueprint.name, next=request.args.get('next')))
 
     def logout(self):
         self.logout_user()


### PR DESCRIPTION
The 'next' GET argument that's sent to the login form isn't being added to the 'action' URL in the form. This bug causes the form to redirect to 'default_next_url' when POSTed, instead of the 'next' argument that's passed to the form.
