### PR TITLE
Allow the default ordering of a ModelAdmin to be customized.

### DIFF
--- a/flask_peewee/admin.py
+++ b/flask_peewee/admin.py
@@ -106,6 +106,9 @@ class ModelAdmin(object):
     filter_mapping = FilterMapping
     filter_converter = AdminFilterModelConverter
 
+    # the default ordering of the index
+    ordering = ''
+
     # templates, to override see get_template_overrides()
     base_templates = {
         'index': 'admin/models/index.html',
@@ -210,7 +213,7 @@ class ModelAdmin(object):
     def index(self):
         query = self.get_query()
 
-        ordering = request.args.get('ordering') or ''
+        ordering = request.args.get('ordering') or self.ordering
         query = self.apply_ordering(query, ordering)
 
         # process the filters from the request


### PR DESCRIPTION
Since the order of the rows was somewhat random I figured it would be nice to be able to set a default order. I couldn't find a way to do it so I added it.
