### PR TITLE
display total number of pages and results in the meta section of an API call

### DIFF
--- a/docs/rest-api.rst
+++ b/docs/rest-api.rst
@@ -99,6 +99,8 @@ Now if we hit our project at ``/api/message/`` we should get something like the 
         "model": "message", 
         "next": "", 
         "page": 1, 
+	"num_pages" 1, 
+	"num_results": 2, 
         "previous": ""
       }, 
       "objects": [
@@ -144,6 +146,8 @@ If you access the ``User`` API endpoint, we quickly notice a problem:
         "model": "user", 
         "next": "", 
         "page": 1, 
+	"num_pages": 1, 
+	"num_results": 2, 
         "previous": ""
       }, 
       "objects": [
@@ -387,6 +391,8 @@ This call will return only messages by the ``User`` with id=2:
         "model": "message", 
         "next": "", 
         "page": 1, 
+	"num_pages": 1, 
+	"num_results": 1, 
         "previous": ""
       }, 
       "objects": [
@@ -412,6 +418,8 @@ Joins can be traversed using the django double-underscore notation:
         "model": "message", 
         "next": "", 
         "page": 1, 
+	"num_pages": 1, 
+	"num_results": 2, 
         "previous": ""
       }, 
       "objects": [
@@ -443,6 +451,8 @@ It is also supported to use different comparison operators with the same double-
         "model": "user",
         "next": "",
         "page": 1,
+	"num_pages": 1,
+	"num_results": 1,
         "previous": ""
         }, 
     "objects": [{
@@ -482,7 +492,7 @@ can specify a ``limit`` in the querystring.
 `/api/messages/?limit=2`
 
 In the "meta" section of the response, URIs for the "next" and "previous" sets
-of results are available:
+of results, the total number of results, and total number of pages are available:
 
 .. code-block:: javascript
 
@@ -490,5 +500,7 @@ of results are available:
       model: "message"
       next: "/api/message/?limit=1&page=3"
       page: 2
+      num_pages: 3,
+      num_results: 3,
       previous: "/api/message/?limit=1&page=1"
     }

--- a/flask_peewee/rest.py
+++ b/flask_peewee/rest.py
@@ -368,6 +368,8 @@ class RestResource(object):
 
         return {
             'model': self.get_api_name(),
+            'num_pages': paginated_query.get_pages(),
+            'num_results': paginated_query.get_count(),
             'page': current_page,
             'previous': previous,
             'next': next,

--- a/flask_peewee/tests/rest.py
+++ b/flask_peewee/tests/rest.py
@@ -567,6 +567,8 @@ class RestApiBasicTestCase(RestApiTestCase):
             'model': 'note',
             'previous': '',
             'next': '',
+            'num_pages': 1,
+            'num_results': 10,
             'page': 1,
         })
         self.assertAPINotes(resp_json, self.normal.note_set.order_by(Note.id))
@@ -579,6 +581,8 @@ class RestApiBasicTestCase(RestApiTestCase):
             'model': 'note',
             'previous': '',
             'next': '',
+            'num_pages': 1,
+            'num_results': 10,
             'page': 1,
         })
         self.assertAPINotes(resp_json, self.admin.note_set.order_by(Note.id))
@@ -599,6 +603,8 @@ class RestApiBasicTestCase(RestApiTestCase):
             'model': 'note',
             'previous': '',
             'next': '',
+            'num_pages': 1,
+            'num_results': 20,
             'page': 1,
         })
         self.assertAPINotes(resp_json, Note.filter(user__in=[self.admin, self.inactive]).order_by(Note.id))
@@ -676,7 +682,7 @@ class RestApiUserAuthTestCase(RestApiTestCase):
         resp_json = self.response_json(resp)
 
         self.assertAPIResponse(resp_json, [])
-        self.assertAPIMeta(resp_json, {'model': 'note', 'next': '', 'page': 1, 'previous': ''})
+        self.assertAPIMeta(resp_json, {'model': 'note', 'next': '', 'page': 1, 'previous': '', 'num_pages': 0, 'num_results': 0})
 
         self.create_notes()
 
@@ -816,7 +822,7 @@ class RestApiOwnerAuthTestCase(RestApiTestCase):
         resp_json = self.response_json(resp)
 
         self.assertAPIResponse(resp_json, [])
-        self.assertAPIMeta(resp_json, {'model': 'message', 'next': '', 'page': 1, 'previous': ''})
+        self.assertAPIMeta(resp_json, {'model': 'message', 'next': '', 'page': 1, 'previous': '', 'num_pages': 0, 'num_results': 0})
 
         self.create_messages()
 
@@ -955,7 +961,7 @@ class RestApiAdminAuthTestCase(RestApiTestCase):
         resp_json = self.response_json(resp)
 
         self.assertAPIResponse(resp_json, [])
-        self.assertAPIMeta(resp_json, {'model': 'user', 'next': '', 'page': 1, 'previous': ''})
+        self.assertAPIMeta(resp_json, {'model': 'user', 'next': '', 'page': 1, 'previous': '', 'num_pages': 0, 'num_results': 0})
 
         self.create_users()
 
@@ -1128,7 +1134,7 @@ class RestApiKeyAuthTestCase(RestApiTestCase):
                 self.tm1,
                 self.tm2,
             ])
-            self.assertAPIMeta(resp_json, {'model': 'testmodel', 'next': '', 'page': 1, 'previous': ''})
+            self.assertAPIMeta(resp_json, {'model': 'testmodel', 'next': '', 'page': 1, 'previous': '', 'num_pages': 1, 'num_results': 2})
 
     def test_auth_headers(self):
         with self.flask_app.test_client() as c:

--- a/flask_peewee/utils.py
+++ b/flask_peewee/utils.py
@@ -51,6 +51,9 @@ class PaginatedQuery(object):
     def get_pages(self):
         return int(math.ceil(float(self.query.count()) / self.paginate_by))
 
+    def get_count(self):
+        return self.query.count()
+
     def get_list(self):
         return self.query.paginate(self.get_page(), self.paginate_by)
 


### PR DESCRIPTION
Some Flask API frameworks, such as Flask-Restless, currently report total number of pages on each API call. In my projects, I sometimes find myself wanting this information readily available on each API call, in addition with the total number of available results. Especially when I build frontends that pulls data directly from my APIs.

This pull-requests extends the Meta field of all API calls with 'num_pages' and 'num_results', reporting total number of pages and total number of results available for that particular API call.

Tests are changed accordingly and all run successfully.

Documentation changed accordingly.
