### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ This package is in maintenance-only mode!
 
 I'm sorry to announce that flask-peewee will now be in maintenance-only mode. This decision is motivated by a number of factors:
 
-* `Flask-Admin <http://flask-admin.readthedocs.org/en/latest/>`_ provides a superior admin interface and has support for peewee models.
-* `Flask-Security <https://pythonhosted.org/Flask-Security/>`_ and `Flask-Login <https://flask-login.readthedocs.org/en/latest/>`_ both provide authentication functionality, and work well with Peewee.
+* `Flask-Admin <https://flask-admin.readthedocs.io/en/latest/>`_ provides a superior admin interface and has support for peewee models.
+* `Flask-Security <https://pythonhosted.org/Flask-Security/>`_ and `Flask-Login <https://flask-login.readthedocs.io/en/latest/>`_ both provide authentication functionality, and work well with Peewee.
 * Most importantly, though, I do not find myself wanting to work on flask-peewee.
 
 I plan on rewriting the ``Database`` and ``REST API`` portions of flask-peewee and repackaging them as a new library, but flask-peewee as it stands currently will be in maintenance-only mode.
@@ -13,7 +13,7 @@ flask-peewee
 ============
 
 provides a layer of integration between the `flask <http://flask.pocoo.org/>`_
-web framework and the `peewee orm <http://peewee.readthedocs.org/>`_.
+web framework and the `peewee orm <https://peewee.readthedocs.io/>`_.
 
 batteries included:
 
@@ -30,7 +30,7 @@ requirements:
 * python 2.5 or greater
 
 
-check out the `documentation <http://flask-peewee.readthedocs.org/>`_.
+check out the `documentation <https://flask-peewee.readthedocs.io/>`_.
 
 
 admin interface

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -8,7 +8,7 @@ further ado, let's get started.
 
 .. note::
     Hopefully you have some familiarity with the `flask framework <http://flask.pocoo.org/>`_ and
-    the `peewee orm <http://peewee.rtfd.org/>`_, but if not those links
+    the `peewee orm <https://peewee.readthedocs.io/>`_, but if not those links
     should help you get started.
 
 .. note::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,8 +13,8 @@ flask-peewee
 
     I'm sorry to announce that flask-peewee will now be in maintenance-only mode. This decision is motivated by a number of factors:
 
-    * `Flask-Admin <http://flask-admin.readthedocs.org/en/latest/>`_ provides a superior admin interface and has support for peewee models.
-    * `Flask-Security <https://pythonhosted.org/Flask-Security/>`_ and `Flask-Login <https://flask-login.readthedocs.org/en/latest/>`_ both provide authentication functionality, and work well with Peewee.
+    * `Flask-Admin <https://flask-admin.readthedocs.io/en/latest/>`_ provides a superior admin interface and has support for peewee models.
+    * `Flask-Security <https://pythonhosted.org/Flask-Security/>`_ and `Flask-Login <https://flask-login.readthedocs.io/en/latest/>`_ both provide authentication functionality, and work well with Peewee.
     * Most importantly, though, I do not find myself wanting to work on flask-peewee.
 
     I plan on rewriting the ``Database`` and ``REST API`` portions of flask-peewee and repackaging them as a new library, but flask-peewee as it stands currently will be in maintenance-only mode.
@@ -24,7 +24,7 @@ flask-peewee
 Welcome to the flask-peewee documentation!
 
 provides a layer of integration between the `flask <http://flask.pocoo.org/>`_
-web framework and the `peewee orm <http://peewee.rtfd.org/>`_.
+web framework and the `peewee orm <https://peewee.readthedocs.io/>`_.
 
 Contents:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.