### PR TITLE
db.py: Database.connect_db(): do nothing if already connected

### DIFF
--- a/flask_peewee/db.py
+++ b/flask_peewee/db.py
@@ -45,7 +45,7 @@ class Database(object):
         return BaseModel
 
     def connect_db(self):
-        self.database.connect()
+        self.database.get_conn()
 
     def close_db(self, exc):
         if not self.database.is_closed():


### PR DESCRIPTION
With SQLite, this fixes
peewee.OperationalError
    raise OperationalError('Connection already open')
when following the Flask-Security "Basic Peewee Application" example
https://pythonhosted.org/Flask-Security/quickstart.html#id3

Test environment:
pip install flask-security flask-peewee
Successfully installed Flask-0.12 Flask-Login-0.3.2 Flask-Mail-0.9.1
Flask-Principal-0.4.0 Flask-WTF-0.14.2 MarkupSafe-0.23 blinker-1.4
click-6.7 flask-peewee-0.6.7 flask-security-1.7.5 itsdangerous-0.24
jinja2-2.9.5 passlib-1.7.1 peewee-2.8.8 werkzeug-0.11.15
wtf-peewee-0.2.6 wtforms-2.1