### PR TITLE
Travis-ci: added support for ppc64le and arranged the matrix in prope…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,35 @@
 language: python
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-dist: trusty
 matrix:
   include:
+    - python: 2.7
+      dist: trusty
+      arch: amd64
+    - python: 3.4 
+      dist: trusty
+      arch: amd64
+    - python: 3.5
+      dist: trusty
+      arch: amd64
+    - python: 3.6
+      dist: trusty
+      arch: amd64
+    - python: 2.7
+      dist: trusty
+      arch: ppc64le
+    - python: 3.5
+      dist: trusty
+      arch: ppc64le
+    - python: 3.6
+      dist: trusty
+      arch: ppc64le
     - python: 3.7
       dist: xenial
       sudo: true
+      arch: amd64
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      arch: ppc64le
+
 install: "pip install peewee flask wtforms wtf-peewee"
 script: "python runtests.py"


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/flask-peewee/builds/189455342 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!